### PR TITLE
feat(app.forecast): add weekly forecast support (#43)

### DIFF
--- a/Nubrio.Application/DTOs/WeeklyForecast/DaysDto.cs
+++ b/Nubrio.Application/DTOs/WeeklyForecast/DaysDto.cs
@@ -1,0 +1,8 @@
+namespace Nubrio.Application.DTOs.WeeklyForecast;
+
+public record DaysDto
+{
+    public required DateOnly Date { get; init; }
+    public required string Condition { get; init; }
+    public required double TemperatureMean { get; init; }
+}

--- a/Nubrio.Application/DTOs/WeeklyForecast/WeeklyForecastDto.cs
+++ b/Nubrio.Application/DTOs/WeeklyForecast/WeeklyForecastDto.cs
@@ -1,0 +1,8 @@
+namespace Nubrio.Application.DTOs.WeeklyForecast;
+
+public record WeeklyForecastDto
+{
+    public required string City { get; init; }
+    public required IReadOnlyList<DaysDto> Days { get; init; }
+    public required DateTimeOffset FetchedAt{ get; init; }
+}

--- a/Nubrio.Application/Interfaces/IWeatherForecastService.cs
+++ b/Nubrio.Application/Interfaces/IWeatherForecastService.cs
@@ -1,20 +1,17 @@
 using FluentResults;
 using Nubrio.Application.DTOs.CurrentForecast;
 using Nubrio.Application.DTOs.DailyForecast;
-using Nubrio.Domain.Models;
+using Nubrio.Application.DTOs.WeeklyForecast;
 
 namespace Nubrio.Application.Interfaces;
 
 public interface IWeatherForecastService
 {
     Task<Result<CurrentForecastDto>> GetCurrentForecastAsync(string city, CancellationToken cancellationToken);
-    
+
     Task<Result<DailyForecastDto>> GetDailyForecastByDateAsync(
         string city, DateOnly date, CancellationToken cancellationToken);
-    
-    Task<Result<DailyForecastDto>> GetDailyForecastRangeAsync(
-        string city, DateOnly startDate,  DateOnly endDate, CancellationToken cancellationToken);
-    
-    
-    
+
+    Task<Result<WeeklyForecastDto>> GetForecastByWeekAsync(
+        string city, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
### Описание:
Добавляет возможность получения недельного прогноза погоды в слой `Application`.

### Изменения:
- Добавлен метод `GetForecastByWeekAsync` в `IWeatherForecastService`
- Реализован`GetForecastByWeekAsync` в `WeatherForecastService`
- Добавлены DTO: `WeeklyForecastDto` и `DaysDto`
- Добавлен внутренний helper-метод `ResolveLocationAsync` инкапсулирующий валидацию города и выполнение геокодинга

### Linked issue:
Closes #43
